### PR TITLE
Memory leak issue. Delete a notifier with no callbacks. This is done in Object.unobserve

### DIFF
--- a/Object.observe.poly.js
+++ b/Object.observe.poly.js
@@ -240,7 +240,16 @@ if(!Object.observe){
     };
     extend.unobserve = function(O, callback){
       validateArguments(O, callback);
-      extend.getNotifier(O).removeListener(callback);
+      var idx = _indexes.indexOf(O),
+          notifier = idx>-1?_notifiers[idx]:false;
+      if (!notifier){
+        return;
+      }
+      notifier.removeListener(callback);
+      if (notifier.listeners().length === 0){
+        _indexes.splice(idx, 1);
+        _notifiers.splice(idx, 1);
+      }
     };
   })(Object, this);
 }


### PR DESCRIPTION
Without the proposed modification, after calling: 
    Object.observe(someObject, someCallback);
    Object.unobserve(someObject, someCallback);
A notifier for someObject and a reference to someObject will exist even if someObject is not used anymore.
This can cause a memory leak 
